### PR TITLE
fix: remove double-free in ble_stream_close

### DIFF
--- a/Sources/LibDCBridge/src/configuredc.c
+++ b/Sources/LibDCBridge/src/configuredc.c
@@ -172,11 +172,12 @@ static dc_status_t ble_stream_sleep(dc_iostream_t *iostream, unsigned int millis
  *------------------------------------------------------------------*/
 static dc_status_t ble_stream_close(dc_iostream_t *iostream)
 {
-    printf("DC_IO [CLOSE]\n");
     ble_stream_t *s = (ble_stream_t *) iostream;
     dc_status_t rc = ble_close(s->ble_object);
     freeBLEObject(s->ble_object);
-    free(s);
+    // Do NOT free(s) here — dc_iostream_close calls dc_iostream_deallocate
+    // after this vtable close returns, which frees the iostream memory.
+    // Freeing here causes a double-free crash (POINTER_BEING_FREED_WAS_NOT_ALLOCATED).
     return rc;
 }
 


### PR DESCRIPTION
  dc_iostream_close calls dc_iostream_deallocate after the vtable close
  function returns, which frees the iostream. Calling free(s) inside
  ble_stream_close caused a crash (POINTER_BEING_FREED_WAS_NOT_ALLOCATED)
  on any code path that closes a BLE iostream.